### PR TITLE
fix: UTF-8 encoding and DML support for app.py

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -25,7 +25,13 @@ def connect():
 # Run student-defined queries from queries.sql
 def run_queries_from_file(engine, filepath):
     try:
-        with open(filepath, 'r') as file:
+        # FIX 1 — UTF-8 Encoding:
+        # The original open() call did not specify an encoding, so Python used
+        # the system default (cp1252 on Windows). This caused the error:
+        # 'charmap' codec can't decode byte 0x8f
+        # because queries.sql contains UTF-8 characters (accents, emojis).
+        # Fix: explicitly specify encoding='utf-8'.
+        with open(filepath, 'r', encoding='utf-8') as file:
             content = file.read()
         queries = [q.strip() for q in content.split(';') if q.strip()]
         for i, query in enumerate(queries, start=0):
@@ -34,8 +40,22 @@ def run_queries_from_file(engine, filepath):
                 continue
             try:
                 print(f"\n🔎 Query {i}:\n{query}")
-                df = pd.read_sql(query, con=engine)
-                print(df)
+                # FIX 2 — DML statement support (INSERT, UPDATE, DELETE):
+                # pd.read_sql() only works with SELECT, as it expects rows in return.
+                # For INSERT/UPDATE/DELETE it raised the error:
+                # "This result object does not return rows. It has been closed automatically."
+                # Fix: detect the statement type and use engine.begin() + sqlalchemy.text()
+                # for DML operations, which opens a transaction and auto-commits on exit.
+                # pd.read_sql() is kept for SELECT statements.
+                first_word = query.strip().split()[0].upper()
+                if first_word in ('INSERT', 'UPDATE', 'DELETE'):
+                    with engine.begin() as conn:
+                        from sqlalchemy import text
+                        conn.execute(text(query))
+                    print("✅ Executed successfully.")
+                else:
+                    df = pd.read_sql(query, con=engine)
+                    print(df)
             except Exception as e:
                 print(f"❌ Error in Query {i}: {e}")
     except Exception as e:


### PR DESCRIPTION
## What and why                                                                                                                    
                                                                                                                                     
While completing the SQL analysis exercise I ran into two bugs in `app.py` that affect all students. I investigated the root cause 
of each one and fixed them after finishing the exercise.                                                                           
                                                                                                                                   
## Changes in `src/app.py`

**FIX 1 — UTF-8 encoding**
The original `open()` call did not specify an encoding, so Python used the OS default (cp1252 on Windows). This caused the error:
`charmap codec can't decode byte 0x8f`
because `queries.sql` contains UTF-8 characters (accents, emojis).
Fix: added `encoding='utf-8'` explicitly to the `open()` call.

**FIX 2 — DML support (INSERT, UPDATE, DELETE)**
`pd.read_sql()` only handles SELECT statements, as it expects rows in return. For INSERT/UPDATE/DELETE it raised:
`This result object does not return rows. It has been closed automatically.`
Fix: detect the statement type and route DML operations to `engine.begin()` with `sqlalchemy.text()`, which handles transactions
correctly. SELECT statements continue using `pd.read_sql()`.

## Note
Both fixes are documented with inline comments in `app.py` explaining the original issue and the solution applied.